### PR TITLE
Delete find_erts_dir function

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -54,20 +54,6 @@ case `uname -s` in
     *);;
 esac
 
-find_erts_dir() {
-    __erts_dir="$RUNNER_ROOT_DIR/erts-$ERTS_VSN"
-    if [ -d "$__erts_dir" ]; then
-        ERTS_DIR="$__erts_dir";
-        ROOTDIR="$RUNNER_ROOT_DIR"
-    else
-        __erl="$(which erl)"
-        code="io:format(\"~s\", [code:root_dir()]), halt()."
-        __erl_root="$("$__erl" -noshell -eval "$code")"
-        ERTS_DIR="$__erl_root/erts-$ERTS_VSN"
-        ROOTDIR="$__erl_root"
-    fi
-}
-
 # Get node pid
 relx_get_pid() {
     if output="$(relx_nodetool rpcterms os getpid)"
@@ -223,8 +209,8 @@ else
     PROTO_DIST_ARG="-proto_dist $PROTO_DIST"
 fi
 
-find_erts_dir
 export ROOTDIR="$RUNNER_ROOT_DIR"
+export ERTS_DIR="$ROOTDIR/erts-$ERTS_VSN"
 export BINDIR="$ERTS_DIR/bin"
 export EMU="beam"
 export PROGNAME="erl"


### PR DESCRIPTION
emqx release should always use packed erts, not the system provided