### PR TITLE
Always assume emqx is installed to /usr/lib/emqx

### DIFF
--- a/vars-pkg.config
+++ b/vars-pkg.config
@@ -12,7 +12,7 @@
 %%
 %% bin/emqx
 %%
-{runner_root_dir, "$(if [ -d /usr/lib64 ]; then echo /usr/lib64; else echo /usr/lib; fi)/emqx"}.
+{runner_root_dir, "/usr/lib/emqx"}.
 {runner_bin_dir,  "/usr/bin"}.
 {runner_etc_dir,  "/etc/emqx"}.
 {runner_lib_dir,  "$RUNNER_ROOT_DIR/lib"}.


### PR DESCRIPTION
Stop guessing /usr/lib64 to overly complicate it