### PR TITLE
Rename VSN in Makefile to a less-clashing name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 PROJECT = emqx-rel
 PROJECT_DESCRIPTION = Release Project for EMQ X Broker
-PROJECT_VERSION = 3.0
 
 # All emqx app names. Repo name, not Erlang app name
 # By default, app name is the same as repo name with dash replaced by underscore.
@@ -19,7 +18,7 @@ REL_PROFILE ?= dev
 
 # Default version for all OUR_APPS
 ## This is either a tag or branch name for ALL dependencies
-VSN ?= emqx30
+EMQX_DEPS_DEFAULT_VSN ?= emqx30
 
 dash = -
 uscore = _
@@ -28,8 +27,8 @@ uscore = _
 # Replace dashes with underscores
 app_name = $(subst $(dash),$(uscore),$(1))
 
-# set emqx_app_name_vsn = x.y.z to override default VSN
-app_vsn = $(if $($(call app_name,$(1))_vsn),$($(call app_name,$(1))_vsn),$(VSN))
+# set emqx_app_name_vsn = x.y.z to override default version
+app_vsn = $(if $($(call app_name,$(1))_vsn),$($(call app_name,$(1))_vsn),$(EMQX_DEPS_DEFAULT_VSN))
 
 DEPS += $(foreach dep,$(OUR_APPS),$(call app_name,$(dep)))
 
@@ -47,9 +46,16 @@ else
 endif
 
 # Override default git full-clone with depth=1 shallow-clone
+ifeq ($(GIT_VSN_17_COMP),1.7)
 define dep_fetch_git-emqx
-	git clone $(MAYBE_SHALLOW) -b $(call dep_commit,$(1)) -- $(call dep_repo,$(1)) $(DEPS_DIR)/$(call app_name,$(1))
+	git clone -q -n -- $(call dep_repo,$(1)) $(DEPS_DIR)/$(call dep_name,$(1)); \
+		cd $(DEPS_DIR)/$(call dep_name,$(1)) && git checkout -q $(call dep_commit,$(1))
 endef
+else
+define dep_fetch_git-emqx
+	git clone -q -c advice.detachedHead=false --depth 1 -b $(call dep_commit,$(1)) -- $(call dep_repo,$(1)) $(DEPS_DIR)/$(call dep_name,$(1))
+endef
+endif
 
 # Add this dependency before including erlang.mk
 all:: OTP_21_OR_NEWER

--- a/erlang.mk
+++ b/erlang.mk
@@ -1186,7 +1186,7 @@ else
 	fi
 	$(appsrc_verbose) cat src/$(PROJECT).app.src \
 		| sed "s/{[[:space:]]*modules[[:space:]]*,[[:space:]]*\[\]}/{modules, \[$(call comma_list,$(MODULES))\]}/" \
-		| sed "s/{id,[[:space:]]*\"git\"}/{id, \"$(subst /,\/,$(GITDESCRIBE))\"}/" \
+		| sed "s/{vsn,[[:space:]]*\"git\"}/{vsn, \"$(subst /,\/,$(GITDESCRIBE))\"}/" \
 		> ebin/$(PROJECT).app
 endif
 


### PR DESCRIPTION
Also made git clone backward compatible for git older than 1.8
because -b option can not be used with git tag in git 1.7