### PR TITLE
Fix git describe in erlang.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ OUR_APPS = emqx emqx-retainer emqx-recon emqx-reloader emqx-dashboard emqx-manag
            emqx-sn emqx-coap emqx-lwm2m emqx-stomp emqx-plugin-template emqx-web-hook \
            emqx-auth-jwt emqx-statsd emqx-delayed-publish emqx-lua-hook
 
-# Auto patch would make the git status dirty which will in turn affect app version
-NO_AUTOPATCH = emqx
-
 # Default release profiles
 RELX_OUTPUT_DIR ?= _rel
 REL_PROFILE ?= dev

--- a/erlang.mk
+++ b/erlang.mk
@@ -1173,7 +1173,7 @@ endef
 ebin/$(PROJECT).app:: $(ERL_FILES) $(CORE_FILES) $(wildcard src/$(PROJECT).app.src)
 	$(eval FILES_TO_COMPILE := $(filter-out src/$(PROJECT).app.src,$?))
 	$(if $(strip $(FILES_TO_COMPILE)),$(call compile_erl,$(FILES_TO_COMPILE)))
-	$(eval GITDESCRIBE := $(shell git describe --dirty --abbrev=7 --tags --always --first-parent 2>/dev/null || true))
+	$(eval GITDESCRIBE := $(shell git describe --abbrev=8 --tags --always 2>/dev/null))
 	$(eval MODULES := $(patsubst %,'%',$(sort $(notdir $(basename \
 		$(filter-out $(ERLC_EXCLUDE_PATHS),$(ERL_FILES) $(CORE_FILES) $(BEAM_FILES)))))))
 ifeq ($(wildcard src/$(PROJECT).app.src),)


### PR DESCRIPTION
To make it backward compatible because --first-parent option
is not available in git 1.8 etc.
Also deleted --dirty option so to allow auto patching
deps without always having a 'dirty' vsn in e.g. emqx.app