### PR TITLE
[WIP] [TAKE-2] Make possible to build release with rebar3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ deps
 *.beam
 *.plt
 erl_crash.dump
+rebar3.crashdump
 ebin
 _rel/*
 .concrete/DEV_MODE
@@ -22,3 +23,5 @@ ct/logs/*
 *.iml
 vars.config
 erlang.mk
+_build
+rebar.lock

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,6 @@ cloud_pkg:
 clean: distclean
 
 distclean:
-	rm -rf _build
-	rm -f data/app.*.config
-	rm -f data/vm.*.args
+	@rm -rf _build
+	@rm -f data/app.*.config
+	@rm -f data/vm.*.args

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ app_name = $(subst $(dash),$(uscore),$(1))
 
 # set emqx_app_name_vsn = x.y.z to override default version
 app_vsn = $(if $($(call app_name,$(1))_vsn),$($(call app_name,$(1))_vsn),$(EMQX_DEPS_DEFAULT_VSN))
+emqx_vsn = build-with-rebar3
 
 DEPS += $(foreach dep,$(MAIN_APPS),$(call app_name,$(dep)))
 
@@ -110,3 +111,5 @@ app:: plugins vm_args relx_conf loaded_plugins vars-ln
 vars-ln:
 	ln -s -f vars-$(REL_PROFILE).config vars.config
 
+distclean::
+	rm -rf _build

--- a/Makefile
+++ b/Makefile
@@ -1,115 +1,28 @@
-PROJECT = emqx-rel
-PROJECT_DESCRIPTION = Release Project for EMQ X Broker
+## shallow clone for speed
 
-# All emqx app names. Repo name, not Erlang app name
-# By default, app name is the same as repo name with dash replaced by underscore.
-# Otherwise define the dependency in regular erlang.mk style:
-## DEPS += emqx
-## dep_emqx = git https://github.com/emqx/emqx.git emqx30
+REBAR_GIT_CLONE_OPTIONS += --depth 1
+export REBAR_GIT_CLONE_OPTIONS
 
-# Default release profiles
-RELX_OUTPUT_DIR ?= _rel
-REL_PROFILE ?= dev
-CLONE_METHOD ?= git-emqx
+REBAR = rebar3
+all: build
 
-# Deploy to edge or cloud
-DEPLOY ?= cloud
+build: cloud_dev
 
-MAIN_APPS = emqx emqx-retainer emqx-management emqx-reloader emqx-sn \
-			emqx-coap emqx-stomp emqx-auth-clientid  emqx-auth-username \
-			emqx-auth-http emqx-auth-jwt emqx-auth-mysql emqx-web-hook \
-			emqx-delayed-publish emqx-recon emqx-psk-file emqx-rule-engine
+edge_dev:
+	rebar3 as edge_dev release
 
-CLOUD_APPS = emqx-lwm2m emqx-auth-ldap emqx-auth-pgsql emqx-auth-redis \
-			 emqx-auth-mongo emqx-lua-hook emqx-plugin-template emqx-dashboard \
-			 emqx-statsd \
+edge_pkg:
+	rebar3 as edge_pkg release
 
-EDGE_APPS = emqx-storm
+cloud_dev:
+	rebar3 as cloud_dev release
 
-ifeq (cloud,$(DEPLOY))
-  MAIN_APPS += $(CLOUD_APPS)
-else
-  MAIN_APPS += $(EDGE_APPS)
-endif
+cloud_pkg:
+	rebar3 as cloud_pkg release
 
-# Default version for all MAIN_APPS
-## This is either a tag or branch name for ALL dependencies
-EMQX_DEPS_DEFAULT_VSN ?= develop
+clean: distclean
 
-dash = -
-uscore = _
-
-# Make Erlang app name from repo name.
-# Replace dashes with underscores
-app_name = $(subst $(dash),$(uscore),$(1))
-
-# set emqx_app_name_vsn = x.y.z to override default version
-app_vsn = $(if $($(call app_name,$(1))_vsn),$($(call app_name,$(1))_vsn),$(EMQX_DEPS_DEFAULT_VSN))
-emqx_vsn = build-with-rebar3
-
-DEPS += $(foreach dep,$(MAIN_APPS),$(call app_name,$(dep)))
-
-# Inject variables like
-# dep_app_name = git-emqx https://github.com/emqx/app-name branch-or-tag
-# for erlang.mk
-$(foreach dep,$(MAIN_APPS),$(eval dep_$(call app_name,$(dep)) = $(CLONE_METHOD) https://github.com/emqx/$(dep) $(call app_vsn,$(dep))))
-
-# Add this dependency before including erlang.mk
-all:: OTP_21_OR_NEWER
-
-# COVER = true
-
-$(shell [ -f erlang.mk ] || curl -s -o erlang.mk https://raw.githubusercontent.com/emqx/erlmk/master/erlang.mk)
-
-include erlang.mk
-
-# Fail fast in case older than OTP 21
-.PHONY: OTP_21_OR_NEWER
-OTP_21_OR_NEWER:
-	@erl -noshell -eval "R = list_to_integer(erlang:system_info(otp_release)), halt(if R >= 21 -> 0; true -> 1 end)"
-
-# Compile options
-ERLC_OPTS += +warn_export_all +warn_missing_spec +warn_untyped_record
-
-plugins:
-	@rm -rf rel
-	@mkdir -p rel/conf/plugins/ rel/schema/
-	@for conf in $(DEPS_DIR)/*/etc/*.conf* ; do \
-		if [ "emqx.conf" = "$${conf##*/}" ] ; then \
-			cp $${conf} rel/conf/ ; \
-		elif [ "acl.conf" = "$${conf##*/}" ] ; then \
-			cp $${conf} rel/conf/ ; \
-		elif [ "ssl_dist.conf" = "$${conf##*/}" ] ; then \
-			cp $${conf} rel/conf/ ; \
-		else \
-			cp $${conf} rel/conf/plugins ; \
-		fi ; \
-	done
-	@for schema in $(DEPS_DIR)/*/priv/*.schema ; do \
-		cp $${schema} rel/schema/ ; \
-	done
-
-vm_args:
-	@if [ $(DEPLOY) = "cloud" ] ; then \
-		cp deps/emqx/etc/vm.args rel/conf/vm.args ; \
-	else \
-		cp deps/emqx/etc/vm.args.$(DEPLOY) rel/conf/vm.args ; \
-	fi ;
-
-relx_conf:
-	@if [ $(DEPLOY) != "cloud" ] ; then \
-		cp relx.config.$(DEPLOY) relx.config ; \
-	fi ;
-
-loaded_plugins:
-	@if [ $(DEPLOY) != "cloud" ] ; then \
-		cp data/loaded_plugins.$(DEPLOY) data/loaded_plugins ; \
-	fi ;
-
-app:: plugins vm_args relx_conf loaded_plugins vars-ln
-
-vars-ln:
-	ln -s -f vars-$(REL_PROFILE).config vars.config
-
-distclean::
+distclean:
 	rm -rf _build
+	rm -f data/app.*.config
+	rm -f data/vm.*.args

--- a/data/loaded_plugins
+++ b/data/loaded_plugins
@@ -1,5 +1,5 @@
 emqx_management.
-emqx_rule_engine.
 emqx_recon.
 emqx_retainer.
 emqx_dashboard.
+emqx_rule_engine.

--- a/data/loaded_plugins.tmpl
+++ b/data/loaded_plugins.tmpl
@@ -1,0 +1,5 @@
+{emqx_management, true}.
+{emqx_recon, true}.
+{emqx_retainer, true}.
+{emqx_dashboard, {{enable_plugin_emqx_dashboard}}}.
+{emqx_rule_engine, {{enable_plugin_emqx_rule_engine}}}.

--- a/post-compile.sh
+++ b/post-compile.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+
+cd ${REBAR_BUILD_DIR}
+
+## Collect config files, some are direct usable
+## some are relx-overlay templated
+rm -rf conf
+mkdir -p conf/plugins
+for conf in lib/*/etc/*.conf* ; do
+    if [ "emqx.conf" = "${conf##*/}" ]; then
+        cp ${conf} conf/
+    elif [ "acl.conf" = "${conf##*/}" ]; then
+        cp ${conf} conf/
+    elif [ "ssl_dist.conf" = "${conf##*/}" ]; then
+        cp ${conf} conf/
+    else
+        cp ${conf} conf/plugins/
+    fi
+done
+
+## Collect all schema files
+mkdir -p conf/schema
+for schema in lib/*/priv/*.schema; do
+    cp ${schema} conf/schema/
+done
+

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,139 @@
+%% NOTE: Order of the deps matters!
+{deps,
+    [ {emqx, {branch, "develop-3.2"}}
+    , {emqx_recon, {branch, "develop-3.2"}}
+    , {emqx_retainer, {branch, "develop-3.2"}}
+    , {emqx_auth_clientid, {branch, "pin-emqx-develop-3.2"}}
+    , {emqx_auth_username, {branch, "pin-emqx-develop-3.2"}}
+    , {emqx_auth_http, {branch, "pin-emqx-develop-3.2"}}
+    , {emqx_auth_mysql, {branch, "pin-emqx-develop-3.2"}}
+    , {emqx_reloader, {branch, "develop-3.2"}}
+    , {emqx_sn, {branch, "pin-emqx-develop-3.2"}}
+    , {emqx_coap, {branch, "pin-emqx-develop-3.2"}}
+    , {emqx_stomp, {branch, "pin-emqx-develop-3.2"}}
+    , {emqx_web_hook, {branch, "develop-3.2"}}
+    , {emqx_auth_jwt, {branch, "pin-emqx-develop-3.2"}}
+    , {emqx_delayed_publish, {branch, "develop-3.2"}}
+    , {emqx_psk_file, {branch, "develop-3.2"}}
+    , {emqx_management, {branch, "pin-emqx-develop-3.2"}}
+    ]}.
+
+%% Added to deps list for 'cloud' profile
+{cloud_deps,
+    [ {emqx_auth_ldap, {branch, "develop-3.2"}}
+    , {emqx_auth_mongo, {branch, "develop-3.2"}}
+    , {emqx_auth_pgsql, {branch, "develop-3.2"}}
+    , {emqx_auth_redis, {branch, "develop-3.2"}}
+    , {emqx_dashboard, {branch, "develop-3.2"}}
+    , {emqx_lua_hook, {branch, "develop-3.2"}}
+    , {emqx_lwm2m, {branch, "upgrade-lwm2m-coap-vsn"}}
+    , {emqx_plugin_template, {branch, "develop-3.2"}}
+    , {emqx_statsd, {branch, "develop-3.2"}}
+    , {emqx_rule_engine, {branch, "pin-emqx-develop-3.2"}}
+    ]}.
+
+{relx,
+    [ {include_src,false}
+    , {extended_start_script,false}
+    , {generate_start_script,false}
+    , {sys_config,false}
+    , {vm_args,false}
+    , {release, {emqx, git_describe},
+        [ kernel
+        , sasl
+        , crypto
+        , public_key
+        , asn1
+        , syntax_tools
+        , ssl
+        , os_mon
+        , inets
+        , compiler
+        , runtime_tools
+        , gproc
+        , esockd
+        , clique
+        , cuttlefish
+        , jsx
+        , cowboy
+        , pbkdf2
+        , bcrypt
+        , emqx
+        , {mnesia, load}
+        , {ekka, load}
+        , {emqx_sn, load}
+        , {emqx_coap, load}
+        , {emqx_recon, load}
+        , {emqx_stomp, load}
+        , {emqx_management, load}
+        , {emqx_rule_engine, load}
+        , {emqx_retainer, load}
+        , {emqx_reloader, load}
+        , {emqx_delayed_publish, load}
+        , {emqx_web_hook, load}
+        , {emqx_auth_clientid, load}
+        , {emqx_auth_username, load}
+        , {emqx_auth_http, load}
+        , {emqx_auth_mysql, load}
+        , {emqx_auth_jwt, load}
+        , {emqx_psk_file, load}
+        ]}
+    , {overlay,
+        [ {mkdir,"etc/"}
+        , {mkdir,"log/"}
+        , {mkdir,"data/"}
+        , {mkdir,"data/mnesia"}
+        , {mkdir,"data/configs"}
+        , {mkdir,"data/scripts"}
+        , {template,"bin/emqx_env","bin/emqx_env"}
+        , {template,"bin/emqx","bin/emqx"}
+        , {template,"bin/emqx_ctl","bin/emqx_ctl"}
+        , {template,"bin/emqx.cmd","bin/emqx.cmd"}
+        , {template,"bin/emqx_ctl.cmd","bin/emqx_ctl.cmd"}
+        , {copy,"{{output_dir}}/../../conf/plugins","etc/"}
+        , {template,"{{output_dir}}/../../conf/emqx.conf","etc/emqx.conf"}
+        , {template,"{{output_dir}}/../../conf/ssl_dist.conf","etc/ssl_dist.conf"}
+        , {template,"{{output_dir}}/../../conf/plugins/emqx_coap.conf", "etc/plugins/emqx_coap.conf"}
+        , {template,"{{output_dir}}/../../conf/plugins/emqx_psk_file.conf", "etc/plugins/emqx_psk_file.conf"}
+        , {template, "data/loaded_plugins.tmpl", "data/loaded_plugins"}
+        , {copy,"{{output_dir}}/../../conf/acl.conf","etc/acl.conf"}
+        , {copy,"bin/nodetool","bin/nodetool"}
+        , {copy,"{{output_dir}}/../../conf/schema","releases/{{rel_vsn}}/"}
+        , {copy,"bin/install_upgrade_escript", "bin/install_upgrade_escript"}
+        , {template,"{{output_dir}}/../../lib/emqx/etc/{{vm_args_file}}","etc/vm.args"}
+        , {copy, "{{output_dir}}/../../lib/emqx/etc/certs","etc/"}
+        , {copy, "{{output_dir}}/../../lib/cuttlefish/cuttlefish","bin/"}
+        , {copy, "{{output_dir}}/../../lib/emqx_psk_file/etc/psk.txt", "etc/psk.txt"}
+        ]}
+    ]}.
+
+{cloud_relx_apps,
+    [ {emqx_auth_ldap, load}
+    , {emqx_auth_mongo, load}
+    , {emqx_auth_pgsql, load}
+    , {emqx_auth_redis, load}
+    , {emqx_dashboard, load}
+    , {emqx_lua_hook, load}
+    , {emqx_lwm2m, load}
+    , {emqx_plugin_template, load}
+    , {emqx_statsd, load}
+    , {observer, load}
+    , luerl
+    , xmerl
+    ]}.
+
+{cloud_relx_overlay,
+    [ {template,"{{output_dir}}/../../conf/plugins/emqx_lwm2m.conf", "etc/plugins/emqx_lwm2m.conf"}
+    , {copy,"{{output_dir}}/../../lib/emqx_lwm2m/lwm2m_xml","etc/"}
+    ]}.
+
+{edoc_opts, [{preprocess,true}]}.
+{erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,
+            warn_obsolete_guard,debug_info]}.
+{xref_checks, [undefined_function_calls,undefined_functions,locals_not_used,
+               deprecated_function_calls,warnings_as_errors,
+               deprecated_functions]}.
+{cover_enabled, true}.
+{cover_opts, [verbose]}.
+{cover_export_enabled, true}.
+{post_hooks, [{'compile', "./post-compile.sh"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -116,7 +116,6 @@
     , {emqx_dashboard, load}
     , {emqx_lua_hook, load}
     , {emqx_lwm2m, load}
-    , {emqx_plugin_template, load}
     , {emqx_statsd, load}
     , {observer, load}
     , luerl

--- a/rebar.config
+++ b/rebar.config
@@ -1,35 +1,35 @@
 %% NOTE: Order of the deps matters!
 {deps,
-    [ {emqx, {branch, "develop-3.2"}}
-    , {emqx_recon, {branch, "develop-3.2"}}
-    , {emqx_retainer, {branch, "develop-3.2"}}
-    , {emqx_auth_clientid, {branch, "pin-emqx-develop-3.2"}}
-    , {emqx_auth_username, {branch, "pin-emqx-develop-3.2"}}
-    , {emqx_auth_http, {branch, "pin-emqx-develop-3.2"}}
-    , {emqx_auth_mysql, {branch, "pin-emqx-develop-3.2"}}
-    , {emqx_reloader, {branch, "develop-3.2"}}
-    , {emqx_sn, {branch, "pin-emqx-develop-3.2"}}
-    , {emqx_coap, {branch, "pin-emqx-develop-3.2"}}
-    , {emqx_stomp, {branch, "pin-emqx-develop-3.2"}}
-    , {emqx_web_hook, {branch, "develop-3.2"}}
-    , {emqx_auth_jwt, {branch, "pin-emqx-develop-3.2"}}
-    , {emqx_delayed_publish, {branch, "develop-3.2"}}
-    , {emqx_psk_file, {branch, "develop-3.2"}}
-    , {emqx_management, {branch, "pin-emqx-develop-3.2"}}
+    [ emqx
+    , emqx_management
+    , emqx_recon
+    , emqx_retainer
+    , emqx_auth_clientid
+    , emqx_auth_username
+    , emqx_auth_http
+    , emqx_auth_mysql
+    , emqx_reloader
+    , emqx_sn
+    , emqx_coap
+    , emqx_stomp
+    , emqx_web_hook
+    , emqx_auth_jwt
+    , emqx_delayed_publish
+    , emqx_psk_file
+    %% temp workaround: This is a dep of deps, added here to avoid conflicts
     ]}.
 
 %% Added to deps list for 'cloud' profile
 {cloud_deps,
-    [ {emqx_auth_ldap, {branch, "develop-3.2"}}
-    , {emqx_auth_mongo, {branch, "develop-3.2"}}
-    , {emqx_auth_pgsql, {branch, "develop-3.2"}}
-    , {emqx_auth_redis, {branch, "develop-3.2"}}
-    , {emqx_dashboard, {branch, "develop-3.2"}}
-    , {emqx_lua_hook, {branch, "develop-3.2"}}
-    , {emqx_lwm2m, {branch, "upgrade-lwm2m-coap-vsn"}}
-    , {emqx_plugin_template, {branch, "develop-3.2"}}
-    , {emqx_statsd, {branch, "develop-3.2"}}
-    , {emqx_rule_engine, {branch, "pin-emqx-develop-3.2"}}
+    [ emqx_auth_ldap
+    , emqx_auth_mongo
+    , emqx_auth_pgsql
+    , emqx_auth_redis
+    , emqx_dashboard
+    , emqx_lua_hook
+    , emqx_lwm2m
+    , emqx_statsd
+    , emqx_rule_engine
     ]}.
 
 {relx,
@@ -58,6 +58,7 @@
         , cowboy
         , pbkdf2
         , bcrypt
+        , mysql
         , emqx
         , {mnesia, load}
         , {ekka, load}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,107 @@
+%% ==============================================================================
+%% maybe upload coverdata
+%% ==============================================================================
+
+CONFIG1 = case os:getenv("TRAVIS") of
+              "true" ->
+                  JobId = os:getenv("TRAVIS_JOB_ID"),
+                  [{coveralls_service_job_id, JobId},
+                   {coveralls_coverdata, "_build/test/cover/*.coverdata"},
+                   {coveralls_service_name , "travis-ci"} | CONFIG];
+              _ ->
+                  CONFIG
+          end,
+
+%% ==============================================================================
+%% Dependencies
+%% ==============================================================================
+
+Kf = fun(K, L) -> {K, V} = lists:keyfind(K, 1, L), V end,
+BaseDeps = Kf(deps, CONFIG1),
+CloudDeps = BaseDeps ++ Kf(cloud_deps, CONFIG1),
+
+%% Make a dep element for rebar.config GitRef should be either {tag, Tag} or {branch, Branch}
+MakeDep =
+    fun({Name, {git, _, _}} = App, _DefaultDepRef) ->
+        %% alreay a complete ref
+        App;
+       (App, DefaultDepRef) ->
+        {AppName, GitRef} =
+            case App of
+                {Name, Pinned} when is_tuple(Pinned) -> {Name, Pinned};
+                {Name, Tag} when is_list(Tag) -> {Name, {tag, Tag}};
+                Name when is_atom(Name) -> {Name, DefaultDepRef}
+           end,
+        RepoName = string:join(string:tokens(atom_to_list(AppName), "_"), "-"),
+        URL = "https://github.com/emqx/" ++ RepoName,
+        {AppName, {git, URL, GitRef}}
+    end,
+
+MakeDeps = fun(Deps, DefaultDepRef) -> [MakeDep(App, DefaultDepRef) || App <- Deps] end,
+
+%% TODO: this is only a temporary workaround in order to be backward compatible
+%% The right way is to always pin dependency version in rebar.config
+%% Any dependency that can not be tested and released independently
+%% (i.e. has to be a part of a emqx release in order to be tested)
+%% should not be a dependency but a local application reside in the same repo.
+%% (Meaning: emqx should be an umbrella project)
+DefaultDepRef =
+    case os:getenv("EMQX_DEPS_DEFAULT_VSN") of
+        false -> {branch, "develop"}; %% not set
+        "" -> {branch, "develop"}; %% set empty
+        MaybeTag ->
+            case re:run(MaybeTag, "v\[0-9\]+\.\[0-9\]+\.*") of
+                nomatch -> {branch, MaybeTag};
+                _ -> {tag, MaybeTag}
+            end
+    end,
+
+%% ==============================================================================
+%% Relx configs
+%% ==============================================================================
+
+GitDescribe = [I || I <- os:cmd("git describe --tag --match 'v*'"), I =/= $\n],
+Relx0 = Kf(relx, CONFIG1),
+{release, _, RelxBaseApps} = lists:keyfind(release, 1, Relx0),
+
+RelxOverlay = Kf(overlay, Relx0),
+RelxCloudApps = RelxBaseApps ++ Kf(cloud_relx_apps, CONFIG1),
+RelxCloudOverlay0 = Kf(cloud_relx_overlay, CONFIG1),
+RelxCloudOverlay = RelxOverlay ++ RelxCloudOverlay0,
+
+MakeRelx =
+    fun(Apps, Overlay, Vars) ->
+        VarFiles = ["vars-" ++ atom_to_list(Var) ++ ".config" || Var <- Vars],
+        Relx1 = lists:keystore(release, 1, Relx0, {release, {emqx, GitDescribe}, Apps}),
+        Relx2 = lists:keystore(overlay, 1, Relx1, {overlay, Overlay}),
+        lists:keystore(overlay_vars, 1, Relx2, {overlay_vars, VarFiles})
+    end,
+Relx = fun(Vars) -> MakeRelx(RelxBaseApps, RelxOverlay, Vars) end,
+RelxCloud = fun(Vars) -> MakeRelx(RelxCloudApps, RelxCloudOverlay, Vars) end,
+
+%% ==============================================================================
+%% Profiles
+%% ==============================================================================
+Profiles =
+    [ {edge_dev,  [ {deps, MakeDeps(BaseDeps, {branch, develop})}
+                  , {relx, Relx([edge, dev])}
+                  ]}
+    , {edge_pkg,  [ {deps, MakeDeps(BaseDeps, DefaultDepRef)}
+                  , {relx, Relx([edge, pkg])}
+                  ]}
+    , {cloud_dev, [ {deps, MakeDeps(CloudDeps, {branch, develop})}
+                  , {relx, RelxCloud([cloud, dev])}
+                  ]}
+    , {cloud_pkg, [ {deps, MakeDeps(CloudDeps, DefaultDepRef)}
+                  , {relx, RelxCloud([cloud, pkg])}
+                  ]}
+    ],
+
+Deletes = [deps, relx, cloud_deps, cloud_relx_apps, cloud_relx_overlay],
+Additions = [{profiles, Profiles}],
+
+CONFIG2 = lists:foldl(fun(K, Acc) -> lists:keydelete(K, 1, Acc) end, CONFIG1, Deletes),
+CONFIG3 = lists:foldl(fun({K, V}, Acc) -> lists:keystore(K, 1, Acc, {K, V}) end, CONFIG2, Additions),
+ok = file:write_file("/tmp/emqx.rebar.config", [io_lib:format("~p.\n", [I]) || I <- CONFIG3]),
+CONFIG3.
+

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -83,13 +83,13 @@ RelxCloud = fun(Vars) -> MakeRelx(RelxCloudApps, RelxCloudOverlay, Vars) end,
 %% Profiles
 %% ==============================================================================
 Profiles =
-    [ {edge_dev,  [ {deps, MakeDeps(BaseDeps, {branch, develop})}
+    [ {edge_dev,  [ {deps, MakeDeps(BaseDeps, {branch, "develop-3.2"})}
                   , {relx, Relx([edge, dev])}
                   ]}
     , {edge_pkg,  [ {deps, MakeDeps(BaseDeps, DefaultDepRef)}
                   , {relx, Relx([edge, pkg])}
                   ]}
-    , {cloud_dev, [ {deps, MakeDeps(CloudDeps, {branch, develop})}
+    , {cloud_dev, [ {deps, MakeDeps(CloudDeps, {branch, "develop-3.2"})}
                   , {relx, RelxCloud([cloud, dev])}
                   ]}
     , {cloud_pkg, [ {deps, MakeDeps(CloudDeps, DefaultDepRef)}

--- a/vars-cloud.config
+++ b/vars-cloud.config
@@ -1,0 +1,3 @@
+{enable_plugin_emqx_dashboard, true}.
+{enable_plugin_emqx_rule_engine, true}.
+{vm_args_file, "vm.args"}.

--- a/vars-edge.config
+++ b/vars-edge.config
@@ -1,0 +1,3 @@
+{enable_plugin_emqx_dashboard, false}.
+{enable_plugin_emqx_rule_engine, false}.
+{vm_args_file, "vm.args.edge"}.


### PR DESCRIPTION
This is the very first step deprecating erlang.mk

Not changing dependency versioning and locking issues in this PR,
not that it's not important, but simply because it is a whole different issue
which can be and should be addressed separately.

Marked as WIP because some dependencies have PR to merge.

profiles:
* cloud_dev
* cloud_rel
* edge_dev
* edge_rel

`rebar3 as cloud_dev release` to make a cloud dev release.