### PR TITLE
simplify rebar config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 REBAR_GIT_CLONE_OPTIONS += --depth 1
 export REBAR_GIT_CLONE_OPTIONS
 
-export EMQX_DEPS_DEFAULT_VSN = develop
+# Set this variable to a tag or branch name to use that tag/branch for all emqx repos
+# export EMQX_DEPS_DEFAULT_VSN = develop
 
 REBAR = rebar3
 all: build
@@ -13,34 +14,34 @@ build: emqx
 run: emqx_run
 
 emqx:
-	rebar3 as emqx release
+	rebar3 as dev,cloud release
 
 emqx_clean:
-	rebar3 as emqx clean
+	rebar3 as dev,cloud clean
 
 emqx_run:
-	rebar3 as emqx run
+	rebar3 as dev,cloud run
 
 emqx_pkg:
-	rebar3 as emqx_pkg release
+	rebar3 as pkg,cloud release
 
 emqx_pkg_clean:
-	rebar3 as emqx_pkg clean
+	rebar3 as pkg,cloud clean
 
 emqx_edge:
-	rebar3 as emqx_edge release
+	rebar3 as dev,edge release
 
 emqx_edge_run:
-	rebar3 as emqx_edge run
+	rebar3 as dev,edge run
 
 emqx_edge_clean:
-	rebar3 as emqx_edge clean
+	rebar3 as dev,edge clean
 
 emqx_edge_pkg:
-	rebar3 as emqx_edge_pkg release
+	rebar3 as pkg,edge release
 
 emqx_edge_pkg_clean:
-	rebar3 as emqx_edge_pkg clean
+	rebar3 as pkg,edge clean
 
 clean: distclean
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,147 +1,9 @@
-%% NOTE: Order of the deps matters!
-{deps,
-    [ emqx
-    , emqx_retainer
-    , emqx_management
-    , emqx_reloader
-    , emqx_sn
-    , emqx_coap
-    , emqx_stomp
-    , emqx_auth_clientid
-    , emqx_auth_username
-    , emqx_auth_http
-    , emqx_auth_jwt
-    , emqx_auth_mysql
-    , emqx_web_hook
-    , emqx_delayed_publish
-    , emqx_recon
-    , emqx_psk_file
-    , emqx_rule_engine
-    ]}.
-
-%% Added to deps list for 'cloud' profile
-{cloud_deps,
-    [ emqx_lwm2m
-    , emqx_auth_ldap
-    , emqx_auth_pgsql
-    , emqx_auth_redis
-    , emqx_auth_mongo
-    , emqx_lua_hook
-    , emqx_dashboard
-    , emqx_statsd
-    ]}.
-
-{edge_deps,
-    [emqx_cube]}.
-
-{relx,
-    [ {include_src,false}
-    , {extended_start_script,false}
-    , {generate_start_script,false}
-    , {sys_config,false}
-    , {vm_args,false}
-    , {release, {emqx, git_describe},
-        [ kernel
-        , sasl
-        , crypto
-        , public_key
-        , asn1
-        , syntax_tools
-        , ssl
-        , os_mon
-        , inets
-        , compiler
-        , runtime_tools
-        , gproc
-        , esockd
-        , clique
-        , getopt
-        , cuttlefish
-        , jsx
-        , cowboy
-        , pbkdf2
-        , bcrypt
-        , mysql
-        , emqx
-        , {mnesia, load}
-        , {ekka, load}
-        , {emqx_sn, load}
-        , {emqx_coap, load}
-        , {emqx_recon, load}
-        , {emqx_stomp, load}
-        , {emqx_management, load}
-        , {emqx_rule_engine, load}
-        , {emqx_retainer, load}
-        , {emqx_reloader, load}
-        , {emqx_delayed_publish, load}
-        , {emqx_web_hook, load}
-        , {emqx_auth_clientid, load}
-        , {emqx_auth_username, load}
-        , {emqx_auth_http, load}
-        , {emqx_auth_mysql, load}
-        , {emqx_auth_jwt, load}
-        , {emqx_psk_file, load}
-        ]}
-    , {overlay,
-        [ {mkdir,"etc/"}
-        , {mkdir,"log/"}
-        , {mkdir,"data/"}
-        , {mkdir,"data/mnesia"}
-        , {mkdir,"data/configs"}
-        , {mkdir,"data/scripts"}
-        , {template,"bin/emqx_env","bin/emqx_env"}
-        , {template,"bin/emqx","bin/emqx"}
-        , {template,"bin/emqx_ctl","bin/emqx_ctl"}
-        , {template,"bin/emqx.cmd","bin/emqx.cmd"}
-        , {template,"bin/emqx_ctl.cmd","bin/emqx_ctl.cmd"}
-        , {copy,"{{output_dir}}/../../conf/plugins","etc/"}
-        , {template,"{{output_dir}}/../../conf/emqx.conf","etc/emqx.conf"}
-        , {template,"{{output_dir}}/../../conf/ssl_dist.conf","etc/ssl_dist.conf"}
-        , {template,"{{output_dir}}/../../conf/plugins/emqx_coap.conf", "etc/plugins/emqx_coap.conf"}
-        , {template,"{{output_dir}}/../../conf/plugins/emqx_psk_file.conf", "etc/plugins/emqx_psk_file.conf"}
-        , {template, "data/loaded_plugins.tmpl", "data/loaded_plugins"}
-        , {copy,"{{output_dir}}/../../conf/acl.conf","etc/acl.conf"}
-        , {copy,"bin/nodetool","bin/nodetool"}
-        , {copy,"{{output_dir}}/../../conf/schema","releases/{{rel_vsn}}/"}
-        , {copy,"bin/install_upgrade_escript", "bin/install_upgrade_escript"}
-        , {template,"{{output_dir}}/../../lib/emqx/etc/{{vm_args_file}}","etc/vm.args"}
-        , {copy, "{{output_dir}}/../../lib/emqx/etc/certs","etc/"}
-        , {copy, "{{output_dir}}/../../lib/cuttlefish/cuttlefish","bin/"}
-        , {copy, "{{output_dir}}/../../lib/emqx_psk_file/etc/psk.txt", "etc/psk.txt"}
-        ]}
-    ]}.
-
-{edge_relx_apps,
-    [{emqx_cube, load}]}.
-
-{cloud_relx_apps,
-    [ {emqx_auth_ldap, load}
-    , {emqx_auth_mongo, load}
-    , {emqx_auth_pgsql, load}
-    , {emqx_auth_redis, load}
-    , {emqx_dashboard, load}
-    , {emqx_lua_hook, load}
-    , {emqx_lwm2m, load}
-    , {emqx_statsd, load}
-    , {observer, load}
-    , luerl
-    , xmerl
-    ]}.
-
-{cloud_relx_overlay,
-    [ {template,"{{output_dir}}/../../conf/plugins/emqx_lwm2m.conf", "etc/plugins/emqx_lwm2m.conf"}
-    , {copy,"{{output_dir}}/../../lib/emqx_lwm2m/lwm2m_xml","etc/"}
-    ]}.
-
-{edge_relx_overlay,
-    []}.
-
-{edoc_opts, [{preprocess,true}]}.
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,
-            warn_obsolete_guard,debug_info]}.
+  warn_obsolete_guard,debug_info]}.
+{edoc_opts, [{preprocess,true}]}.
 {xref_checks, [undefined_function_calls,undefined_functions,locals_not_used,
-               deprecated_function_calls,warnings_as_errors,
-               deprecated_functions]}.
+  deprecated_function_calls,warnings_as_errors,
+  deprecated_functions]}.
 {cover_enabled, true}.
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.
@@ -150,3 +12,178 @@
 
 {post_hooks, [ {"(linux|darwin|solaris|freebsd|netbsd|openbsd)", compile, "./post-compile.sh"}
              , {"win32", compile, "post-compile.cmd"}]}.
+
+  %%%==== Custom config ahead =====
+  %% The following keys are not understood by rebar3
+  %% but are translated as appropriate by rebar.config.script
+  %%  - emqx_deps: Translates to {git, _, _} deps
+  %% Note that relx.exclude_apps is understood by rebar3 directly
+  %%%====       End note      =====
+
+  %% NOTE: Order of the deps matters!
+{emqx_deps,
+  [ emqx
+  , emqx_retainer
+  , emqx_management
+  , emqx_reloader
+  , emqx_sn
+  , emqx_coap
+  , emqx_stomp
+  , emqx_auth_clientid
+  , emqx_auth_username
+  , emqx_auth_http
+  , emqx_auth_jwt
+  , emqx_auth_mysql
+  , emqx_web_hook
+  , emqx_delayed_publish
+  , emqx_recon
+  , emqx_psk_file
+  , emqx_rule_engine
+  ]}.
+
+  %% Additional deps from hex.pm or other sources may be added as usual under deps
+
+{relx,
+  [ {include_src,false}
+  , {extended_start_script,false}
+  , {generate_start_script,false}
+  , {sys_config,false}
+  , {vm_args,false}
+  , {release, {emqx_base, {cmd, "git describe --tag --match 'v*' --dirty | tr -d '[:space:]'"}},
+    [ kernel
+    , sasl
+    , crypto
+    , public_key
+    , asn1
+    , syntax_tools
+    , ssl
+    , os_mon
+    , inets
+    , compiler
+    , runtime_tools
+    , gproc
+    , esockd
+    , clique
+    , getopt
+    , cuttlefish
+    , jsx
+    , cowboy
+    , pbkdf2
+    , bcrypt
+    , mysql
+    , emqx
+    , {mnesia, load}
+    , {ekka, load}
+    , {emqx_sn, load}
+    , {emqx_coap, load}
+    , {emqx_recon, load}
+    , {emqx_stomp, load}
+    , {emqx_management, load}
+    , {emqx_rule_engine, load}
+    , {emqx_retainer, load}
+    , {emqx_reloader, load}
+    , {emqx_delayed_publish, load}
+    , {emqx_web_hook, load}
+    , {emqx_auth_clientid, load}
+    , {emqx_auth_username, load}
+    , {emqx_auth_http, load}
+    , {emqx_auth_mysql, load}
+    , {emqx_auth_jwt, load}
+    , {emqx_psk_file, load}
+    ]}
+  , {overlay,
+    [ {mkdir,"etc/"}
+    , {mkdir,"log/"}
+    , {mkdir,"data/"}
+    , {mkdir,"data/mnesia"}
+    , {mkdir,"data/configs"}
+    , {mkdir,"data/scripts"}
+
+    %% scripts in bin/
+    , {template,"bin/emqx_env","bin/emqx_env"}
+    , {template,"bin/emqx","bin/emqx"}
+    , {template,"bin/emqx_ctl","bin/emqx_ctl"}
+    , {template,"bin/emqx.cmd","bin/emqx.cmd"}
+    , {template,"bin/emqx_ctl.cmd","bin/emqx_ctl.cmd"}
+    , {copy,"bin/nodetool","bin/nodetool"}
+    , {copy,"bin/install_upgrade_escript", "bin/install_upgrade_escript"}
+    , {copy, "{{output_dir}}/../../lib/cuttlefish/cuttlefish","bin/"}
+
+    , {template, "data/loaded_plugins.tmpl", "data/loaded_plugins"}
+
+
+    , {template,"{{output_dir}}/../../conf/emqx.conf","etc/emqx.conf"}
+    , {copy,"{{output_dir}}/../../conf/acl.conf","etc/acl.conf"}
+    , {template,"{{output_dir}}/../../lib/emqx/etc/{{vm_args_file}}","etc/vm.args"}
+    , {template,"{{output_dir}}/../../conf/ssl_dist.conf","etc/ssl_dist.conf"}
+
+    , {copy,"{{output_dir}}/../../conf/plugins","etc/"}
+    , {template,"{{output_dir}}/../../conf/plugins/emqx_coap.conf", "etc/plugins/emqx_coap.conf"}
+    , {template,"{{output_dir}}/../../conf/plugins/emqx_psk_file.conf", "etc/plugins/emqx_psk_file.conf"}
+
+    , {copy,"{{output_dir}}/../../conf/schema","releases/{{rel_vsn}}/"}
+
+    , {copy, "{{output_dir}}/../../lib/emqx/etc/certs","etc/"}
+    , {copy, "{{output_dir}}/../../lib/emqx_psk_file/etc/psk.txt", "etc/psk.txt"}
+
+    ]}
+  ]}.
+
+
+{profiles,
+  [ {dev_local,
+    [ {relx,
+      [ {dev_mode, true}
+      , {include_erts, false}
+      , {system_libs, false}
+      ]}
+    , {erl_opts, [debug_info]}
+    ]}
+  , {cloud,
+    [ {emqx_deps,
+      [ emqx_lwm2m
+      , emqx_auth_ldap
+      , emqx_auth_pgsql
+      , emqx_auth_redis
+      , emqx_auth_mongo
+      , emqx_lua_hook
+      , emqx_dashboard
+      , emqx_statsd
+      ]}
+    , {relx,
+      [ {release, {emqx, {cmd, "git describe --tag --match 'v*' --dirty | tr -d '[:space:]'"}, {extend, emqx_base}},
+        [ {emqx_lwm2m, load}
+        , {emqx_auth_ldap, load}
+        , {emqx_auth_pgsql, load}
+        , {emqx_auth_redis, load}
+        , {emqx_auth_mongo, load}
+        , {emqx_lua_hook, load}
+        , {emqx_dashboard, load}
+        , {emqx_statsd, load}
+        , {observer,load}
+        , luerl
+        , xmerl
+        ]
+      }
+      , {overlay,
+        [ {template,"{{output_dir}}/../../conf/plugins/emqx_lwm2m.conf", "etc/plugins/emqx_lwm2m.conf"}
+        , {copy,"{{output_dir}}/../../lib/emqx_lwm2m/lwm2m_xml","etc/"}
+        ]
+      }
+      , {overlay_vars, ["vars-cloud.config"]}
+      , {default_release, {emqx, {cmd, "git describe --tag --match 'v*' --dirty | tr -d '[:space:]'"}}}
+      ]}
+    ]}
+  , {edge,
+    [ {emqx_deps, [ emqx_cube ]}
+    , {relx,
+      [ {release, {emqx, {cmd, "git describe --tag --match 'v*' --dirty | tr -d '[:space:]'"}, {extend, emqx_base}},
+        [{emqx_cube, load}]}
+      , {overlay_vars, ["vars-edge.config"]}
+      , {default_release, {emqx, {cmd, "git describe --tag --match 'v*' --dirty | tr -d '[:space:]'"}}}
+      ]}
+    ]}
+  , {pkg, [{relx, [{overlay_vars, "vars-pkg.config"}]}]}
+  , {dev, [{relx, [{overlay_vars, ["vars-dev.config"]}]}]}
+  , {win32, [{relx, [{exclude_apps, [bcrypt]}]}]}
+  ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -18,29 +18,11 @@ CONFIG1 = case os:getenv("TRAVIS") of
 %% Dependencies
 %% ==============================================================================
 
-Kf = fun(K, L) -> {K, V} = lists:keyfind(K, 1, L), V end,
-BaseDeps = Kf(deps, CONFIG1),
-CloudDeps = BaseDeps ++ Kf(cloud_deps, CONFIG1),
-EdgeDeps = BaseDeps ++ Kf(edge_deps, CONFIG1),
-
-%% Make a dep element for rebar.config GitRef should be either {tag, Tag} or {branch, Branch}
-MakeDep =
-    fun({Name, {git, _, _}} = App, _DefaultDepRef) ->
-        %% alreay a complete ref
-        App;
-       (App, DefaultDepRef) ->
-        {AppName, GitRef} =
-            case App of
-                {Name, Pinned} when is_tuple(Pinned) -> {Name, Pinned};
-                {Name, Tag} when is_list(Tag) -> {Name, {tag, Tag}};
-                Name when is_atom(Name) -> {Name, DefaultDepRef}
-           end,
-        RepoName = string:join(string:tokens(atom_to_list(AppName), "_"), "-"),
-        URL = "https://github.com/emqx/" ++ RepoName,
-        {AppName, {git, URL, GitRef}}
-    end,
-
-MakeDeps = fun(Deps, DefaultDepRef) -> [MakeDep(App, DefaultDepRef) || App <- Deps] end,
+Kf = fun(K, L) -> case lists:keyfind(K, 1, L) of
+                    false -> [];
+                    {K, V} -> V
+                  end
+     end,
 
 %% TODO: this is only a temporary workaround in order to be backward compatible
 %% The right way is to always pin dependency version in rebar.config
@@ -59,57 +41,38 @@ DefaultDepRef =
             end
     end,
 
-%% ==============================================================================
-%% Relx configs
-%% ==============================================================================
-
-GitDescribe = [I || I <- os:cmd("git describe --tag --match \"v*\""), I =/= $\n],
-Relx0 = Kf(relx, CONFIG1),
-{release, _, RelxBaseApps} = lists:keyfind(release, 1, Relx0),
-
-RelxOverlay = Kf(overlay, Relx0),
-RelxCloudApps = RelxBaseApps ++ Kf(cloud_relx_apps, CONFIG1),
-RelxEdgeApps = RelxBaseApps ++ Kf(edge_relx_apps, CONFIG1),
-RelxCloudOverlay0 = Kf(cloud_relx_overlay, CONFIG1),
-RelxEdgeOverlay0 = Kf(edge_relx_overlay, CONFIG1),
-RelxCloudOverlay = RelxOverlay ++ RelxCloudOverlay0,
-RelxEdgeOverlay = RelxOverlay ++ RelxEdgeOverlay0,
-
-MakeRelx =
-    fun(Apps, Overlay, Vars) ->
-        VarFiles = ["vars-" ++ atom_to_list(Var) ++ ".config" || Var <- Vars],
-        Apps1 = case os:type() of {win32, nt} -> Apps -- [bcrypt]; _Other -> Apps end,
-        Relx1 = lists:keystore(release, 1, Relx0, {release, {emqx, GitDescribe}, Apps1}),
-        Relx2 = lists:keystore(overlay, 1, Relx1, {overlay, Overlay}),
-        lists:keystore(overlay_vars, 1, Relx2, {overlay_vars, VarFiles})
+%% Make a dep element for rebar.config GitRef should be either {tag, Tag} or {branch, Branch}
+MakeDep =
+    fun(App) ->
+        {AppName, GitRef} =
+            case App of
+                {Name, Pinned} when is_tuple(Pinned) -> {Name, Pinned};
+                {Name, Tag} when is_list(Tag) -> {Name, {tag, Tag}};
+                Name when is_atom(Name) -> {Name, DefaultDepRef}
+           end,
+        RepoName = string:join(string:tokens(atom_to_list(AppName), "_"), "-"),
+        URL = "https://github.com/emqx/" ++ RepoName,
+        {AppName, {git, URL, GitRef}}
     end,
-Relx = fun(Vars) -> MakeRelx(RelxBaseApps, RelxOverlay, Vars) end,
-RelxCloud = fun(Vars) -> MakeRelx(RelxCloudApps, RelxCloudOverlay, Vars) end,
-RelxEdge = fun(Vars) -> MakeRelx(RelxEdgeApps, RelxEdgeOverlay, Vars) end,
 
-%% ==============================================================================
-%% Profiles
-%% ==============================================================================
-Profiles =
-    [ {emqx, [ {deps, MakeDeps(CloudDeps, {branch, "develop"})}
-                  , {relx, RelxCloud([cloud, dev])}
-                  ]}
-    , {emqx_pkg, [ {deps, MakeDeps(CloudDeps, DefaultDepRef)}
-                  , {relx, RelxCloud([cloud, pkg])}
-                  ]}
-    , {emqx_edge, [ {deps, MakeDeps(EdgeDeps, {branch, "develop"})}
-                  , {relx, RelxEdge([edge, dev])}
-                  ]}
-    , {emqx_edge_pkg, [ {deps, MakeDeps(EdgeDeps, DefaultDepRef)}
-                  , {relx, RelxEdge([edge, pkg])}
-                  ]}
-    ],
+TranslateDeps =
+    fun(C) ->
+        case Kf(emqx_deps, C) of
+          false -> C;
+          DepApps ->
+            EmqxDeps = lists:map(MakeDep, DepApps),
+            ExistingDeps = Kf(deps, C),
+            lists:keyreplace(emqx_deps, 1, C, {deps, ExistingDeps ++ EmqxDeps})
+        end
+    end,
 
-Deletes = [deps, relx, cloud_deps, cloud_relx_apps, cloud_relx_overlay],
-Additions = [{profiles, Profiles}],
-
-CONFIG2 = lists:foldl(fun(K, Acc) -> lists:keydelete(K, 1, Acc) end, CONFIG1, Deletes),
-CONFIG3 = lists:foldl(fun({K, V}, Acc) -> lists:keystore(K, 1, Acc, {K, V}) end, CONFIG2, Additions),
+%% Translate top level emqx_deps (in default profile)
+CONFIG2 = TranslateDeps(CONFIG1),
+%% Translate extra deps from other profiles as well
+UpdatedProfiles = lists:map(
+  fun ({PName, PConfig}) -> {PName, TranslateDeps(PConfig)} end,
+  Kf(profiles, CONFIG2)),
+CONFIG3 = lists:keyreplace(profiles, 1, CONFIG2, {profiles, UpdatedProfiles}),
 
 FilePath = case os:type() of
                {win32, nt} ->

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -57,12 +57,26 @@ MakeDep =
 
 TranslateDeps =
     fun(C) ->
-        case Kf(emqx_deps, C) of
-          false -> C;
-          DepApps ->
-            EmqxDeps = lists:map(MakeDep, DepApps),
-            ExistingDeps = Kf(deps, C),
-            lists:keyreplace(emqx_deps, 1, C, {deps, ExistingDeps ++ EmqxDeps})
+        DepApps = Kf(emqx_deps, C),
+        EmqxDeps = lists:map(MakeDep, DepApps),
+        ExistingDeps = Kf(deps, C),
+        lists:keyreplace(emqx_deps, 1, C, {deps, ExistingDeps ++ EmqxDeps})
+    end,
+
+%% Temporary workaround to malfunctioning {extend, Relname} behaviour in relx releases
+%% Extending mistakenly converts {application, load} to {application, permanent}
+%% This will do some magic until that is debugged and resolved
+TranslateReleases =
+    fun(C) ->
+        Relx = Kf(relx, C),
+        Release = lists:keyfind(release, 1, Relx),
+        case Release of
+          {release, {Name, Vsn, {extend, emqx_base}}, Apps} ->
+            {release, {emqx_base, _}, BaseApps} = lists:keyfind(release, 1, Kf(relx, CONFIG)),
+            NewRel = {release, {Name, Vsn}, BaseApps ++ Apps},
+            Relx1 = lists:keyreplace(release, 1, Relx, NewRel),
+            lists:keyreplace(relx, 1, C, {relx, Relx1});
+          _ -> C
         end
     end,
 
@@ -70,9 +84,11 @@ TranslateDeps =
 CONFIG2 = TranslateDeps(CONFIG1),
 %% Translate extra deps from other profiles as well
 UpdatedProfiles = lists:map(
-  fun ({PName, PConfig}) -> {PName, TranslateDeps(PConfig)} end,
+  fun ({PName, PConfig}) -> {PName, TranslateReleases(TranslateDeps(PConfig))} end,
   Kf(profiles, CONFIG2)),
 CONFIG3 = lists:keyreplace(profiles, 1, CONFIG2, {profiles, UpdatedProfiles}),
+
+
 
 FilePath = case os:type() of
                {win32, nt} ->


### PR DESCRIPTION
Breaking changes:
 - Exporting EMQX_DEPS_DEFAULT_VSN will always use that tag/branch
    Previously non pkg versions were not affected by this.
 - windows builds now need win32 rebar profile to be applied

For local development, export REBAR_PROFILE=dev_local before calling make.

Windows builds should use REBAR_PROFILE=win32 before calling make.

The value of REBAR_PROFILE will be added to any profiles supplied using rebar3 as.

Everything should work, but please test this thoroughly.

How does this work:
When applying multiple profiles,
 - Deps are merged by rebar3 and fetched
 - Overlay vars are [merged by relx internally here](https://github.com/erlware/relx/blob/ba0986b55bbee9b28b9467658312c1d9d93a4b40/src/rlx_config.erl#L271-L275)
 - Overlays are [merged by rebar3 here](https://github.com/erlang/rebar3/blob/6ea0a600b4f560565ca963b69c86b9e9cb0ea0b8/src/rebar_relx.erl#L66-L73)
 - relx understands exclude_apps, so we don't need a script snippet to remove bcrypt on windows
 - Extending releases seems to be an undocumented feature that I [discovered here](https://github.com/erlware/relx/blob/ba0986b55bbee9b28b9467658312c1d9d93a4b40/src/rlx_config.erl#L190-L202). We should also probably document it and contribute upstream.

Top level deps have been renamed to emqx_deps since deps array with bare app names has an existing meaning - the latest version of that package published on hex.pm. By renaming we can also use deps from hex if we want by defining deps as usual.

