### PR TITLE
Updated configmap to fix ReadString error

### DIFF
--- a/deploy/charts/emqx/templates/configmap.yaml
+++ b/deploy/charts/emqx/templates/configmap.yaml
@@ -9,4 +9,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  {{- toYaml .Values.emqxConfig | nindent 2 }}
+  {{- range $index, $value := .Values.emqxConfig}}
+    {{$index}}: "{{ $value }}" 
+  {{- end}}


### PR DESCRIPTION
This pull request fixes issue #448 where @rjbaat has an issue with the configuration mapping.
I have simply reverted the config map to the previous version.

```
failed to install app emqx. Error: release emqx failed: ConfigMap in version \"v1\" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects \" or n, but found f, error found in #10 byte of ...|ONYMOUS\":false,\"EMQX|..., bigger context ...|\"apiVersion\":\"v1\",\"data\":{\"EMQX_ALLOW_ANONYMOUS\":false,\"EMQX_CLUSTER__K8S__ADDRESS_TYPE\":\"hostname\",|...\n
```