### PR TITLE
add missing definition of echoerr function

### DIFF
--- a/bin/emqx_ctl
+++ b/bin/emqx_ctl
@@ -11,6 +11,9 @@ RUNNER_ROOT_DIR="{{ runner_root_dir }}"
 ERTS_VSN="{{ erts_vsn }}"
 RUNNER_ETC_DIR="{{ runner_etc_dir }}"
 
+# Echo to stderr on errors
+echoerr() { echo "$@" 1>&2; }
+
 if [ -z "$WITH_EPMD" ]; then
     EPMD_ARG="-start_epmd false -epmd_module nodetool_epmd"
 else


### PR DESCRIPTION
Provide a clue on why ctl can't be executed. For instance:

```
/opt/emqx/bin/emqx_ctl: line 51: echoerr: not found
['2020-02-18T21:14:24Z']:emqx not running, waiting for recovery in 0 seconds
```

```
vm.args needs to have a -setcookie parameter.
['2020-02-18T21:14:24Z']:emqx not running, waiting for recovery in 0 seconds
```

Example doesn't say much why it cookie can't be found, howerver it pointed to a culprit: [egreg](https://github.com/emqx/emqx-rel/blob/ac33d284fcefbe7b8d703206c21b2e0e3a0cb5d7/bin/emqx_ctl#L38), which failed to parse out cookies from the config file (due to locked file on the file-system by docker):

```
egrep '^[ \t]*node.cookie[ \t]*=[ \t]*' /opt/emqx/etc/emqx.conf
egrep: /opt/emqx/etc/emqx.conf: I/O error
```

Would be much better if `emqx_ctl` could report errors when being executed by docker's entry point - `start.sh` (or directly from shell).