### PR TITLE
Use the API instead of emqx_ctl to get the broker's status

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -42,7 +42,7 @@ COPY deploy/docker/docker-entrypoint.sh deploy/docker/start.sh deploy/docker/tmp
 COPY --from=builder /emqx_rel/_build/emqx*/rel/emqx /opt/emqx
 
 RUN ln -s /opt/emqx/bin/* /usr/local/bin/ 
-RUN apk add --no-cache ncurses-libs openssl sudo libstdc++
+RUN apk add --no-cache curl ncurses-libs openssl sudo libstdc++
 
 WORKDIR /opt/emqx
 

--- a/deploy/docker/start.sh
+++ b/deploy/docker/start.sh
@@ -17,20 +17,7 @@ emqx_exit(){
 
 /opt/emqx/bin/emqx start || emqx_exit
 
-tail -f /opt/emqx/log/emqx.log.1 &
-
-# Wait and ensure emqx status is running
-WAIT_TIME=0
-while [[ -z "$(/opt/emqx/bin/emqx_ctl status |grep 'is running'|awk '{print $1}')" ]]
-do
-    sleep 1
-    echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:waiting emqx"
-    WAIT_TIME=$((WAIT_TIME+1))
-    if [[ $WAIT_TIME -gt $EMQX_WAIT_TIME ]]; then
-        echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:timeout error"
-        exit 1
-    fi
-done
+tail -f /opt/emqx/log/erlang.log.1 &
 
 # Sleep 5 seconds to wait for the loaded plugins catch up.
 sleep 5
@@ -43,16 +30,15 @@ echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx start"
 #          and docker dispatching system can known and restart this container.
 NEW_LOG_NUM=2
 IDLE_TIME=0
-while [[ $IDLE_TIME -lt 5 ]]
-do  
+while [[ $IDLE_TIME -lt 5 ]]; do
     IDLE_TIME=$((IDLE_TIME+1))
-    if [[ ! -z "$(/opt/emqx/bin/emqx_ctl status |grep 'is running'|awk '{print $1}')" ]]; then
+    if [[ ! -z "$(curl http://localhost:8081/status |grep 'is running'|awk '{print $1}')" ]]; then
         IDLE_TIME=0
-        # Print the latest emqx.log
-        if [[ -f /opt/emqx/log/emqx.log.${NEW_LOG_NUM} ]];then
-            tail -f /opt/emqx/log/emqx.log.${NEW_LOG_NUM} &
-            [[ ! -z $(ps -ef |grep "tail -f /opt/emqx/log/emqx.log" | grep -vE "grep|emqx.log.${NEW_LOG_NUM}" | awk '{print $1}') ]] && kill $(ps -ef |grep "tail -f /opt/emqx/log/emqx.log" | grep -vE "grep|emqx.log.${NEW_LOG_NUM}" | awk '{print $1}') 
-            NEW_LOG_NUM=$((NEW_LOG_NUM+1)) 
+        # Print the latest erlang.log
+        if [[ -f /opt/emqx/log/erlang.log.${NEW_LOG_NUM} ]];then
+            tail -f /opt/emqx/log/erlang.log.${NEW_LOG_NUM} &
+            [[ ! -z $(ps -ef |grep "tail -f /opt/emqx/log/erlang.log" | grep -vE "grep|erlang.log.${NEW_LOG_NUM}" | awk '{print $1}') ]] && kill $(ps -ef |grep "tail -f /opt/emqx/log/erlang.log" | grep -vE "grep|erlang.log.${NEW_LOG_NUM}" | awk '{print $1}') 
+            NEW_LOG_NUM=$((NEW_LOG_NUM+1))
         fi
     else
         echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx not running, waiting for recovery in $((25-IDLE_TIME*5)) seconds"

--- a/deploy/docker/start.sh
+++ b/deploy/docker/start.sh
@@ -30,9 +30,11 @@ echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx start"
 #          and docker dispatching system can known and restart this container.
 NEW_LOG_NUM=2
 IDLE_TIME=0
+MGMT_CONF='/opt/emqx/etc/plugins/emqx_management.conf'
+MGMT_PORT=$(sed -n -r '/^management.listener.http[ \t]=[ \t].*$/p' $MGMT_CONF | sed -r 's/^management.listener.http = (.*)$/\1/g')
 while [[ $IDLE_TIME -lt 5 ]]; do
     IDLE_TIME=$((IDLE_TIME+1))
-    if [[ ! -z "$(curl http://localhost:8081/status |grep 'is running'|awk '{print $1}')" ]]; then
+    if curl http://localhost:${MGMT_PORT}/status >/dev/null 2>&1; then
         IDLE_TIME=0
         # Print the latest erlang.log
         if [[ -f /opt/emqx/log/erlang.log.${NEW_LOG_NUM} ]];then


### PR DESCRIPTION
+ Use the API instead of emqx_ctl to get the broker's status
+ Output to the container using erlang.log instead of emqx.log
+ Fix https://github.com/emqx/emqx/issues/3274