### PR TITLE
[helm] chart using if-else instead of default

### DIFF
--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -76,12 +76,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-          - containerPort: {{ .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL | default 1883 }}
-          - containerPort: {{ .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL | default 8883 }}
-          - containerPort: {{ .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP | default 8081 }}
-          - containerPort: {{ .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL | default 8083 }}
-          - containerPort: {{ .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL | default 8084 }}
-          - containerPort: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP | default 18083 }}
+          - containerPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__TCP__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL {{ else }} 1883 {{ end }}
+          - containerPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__SSL__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL {{ else }} 8883 {{ end }}
+          - containerPort: {{if hasKey .Values.emqxConfig "EMQX_MANAGEMENT__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP {{ else }} 8081 {{ end }}
+          - containerPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL {{ else }} 8083 {{ end }}
+          - containerPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WSS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL {{ else }} 8084 {{ end }}
+          - containerPort: {{if hasKey .Values.emqxConfig "EMQX_DASHBOARD__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP {{ else }} 18083 {{ end }}
           envFrom:
             - configMapRef:
                 name: {{ include "emqx.fullname" . }}-env 
@@ -113,7 +113,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /status
-              port: {{ .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP | default 8081 }}
+              port: {{if hasKey .Values.emqxConfig "EMQX_MANAGEMENT__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP {{ else }} 8081 {{ end }}
             initialDelaySeconds: 5
             periodSeconds: 5
     {{- with .Values.nodeSelector }}

--- a/deploy/charts/emqx/templates/service.yaml
+++ b/deploy/charts/emqx/templates/service.yaml
@@ -12,29 +12,29 @@ spec:
   type: {{ .Values.service.type }} 
   ports:
   - name: mqtt
-    port: {{ .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL | default 1883 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__TCP__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL {{ else }} 1883 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL | default 1883 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__TCP__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL {{ else }} 1883 {{ end }}
   - name: mqttssl
-    port: {{ .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL | default 8883 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__SSL__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL {{ else }} 8883 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL | default 8883 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__SSL__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL {{ else }} 8883 {{ end }}
   - name: mgmt
-    port: {{ .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP | default 8081 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_MANAGEMENT__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP {{ else }} 8081 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP | default 8081 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_MANAGEMENT__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP {{ else }} 8081 {{ end }}
   - name: websocket
-    port: {{ .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL | default 8083 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL {{ else }} 8083 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL | default 8083 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL {{ else }} 8083 {{ end }}
   - name: wss
-    port: {{ .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL | default 8084 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WSS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL {{ else }} 8084 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL | default 8084 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WSS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL {{ else }} 8084 {{ end }}
   - name: dashboard
-    port: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP | default 18083 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_DASHBOARD__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP {{ else }} 18083 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP | default 18083 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_DASHBOARD__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP {{ else }} 18083 {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "emqx.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -56,29 +56,29 @@ spec:
   clusterIP: None
   ports:
   - name: mqtt
-    port: {{ .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL | default 1883 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__TCP__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL {{ else }} 1883 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL | default 1883 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__TCP__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL {{ else }} 1883 {{ end }}
   - name: mqttssl
-    port: {{ .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL | default 8883 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__SSL__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL {{ else }} 8883 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL | default 8883 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__SSL__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__SSL__EXTERNAL {{ else }} 8883 {{ end }}
   - name: mgmt
-    port: {{ .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP | default 8081 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_MANAGEMENT__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP {{ else }} 8081 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP | default 8081 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_MANAGEMENT__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_MANAGEMENT__LISTENER__HTTP {{ else }} 8081 {{ end }}
   - name: websocket
-    port: {{ .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL | default 8083 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL {{ else }} 8083 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL | default 8083 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WS__EXTERNAL {{ else }} 8083 {{ end }}
   - name: wss
-    port: {{ .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL | default 8084 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WSS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL {{ else }} 8084 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL | default 8084 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_LISTENER__WSS__EXTERNAL" }} .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL {{ else }} 8084 {{ end }}
   - name: dashboard
-    port: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP | default 18083 }}
+    port: {{if hasKey .Values.emqxConfig "EMQX_DASHBOARD__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP {{ else }} 18083 {{ end }}
     protocol: TCP
-    targetPort: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP | default 18083 }}
+    targetPort: {{if hasKey .Values.emqxConfig "EMQX_DASHBOARD__LISTENER__HTTP" }} .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP {{ else }} 18083 {{ end }}
   selector:
     app.kubernetes.io/name: {{ include "emqx.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
the chart fails when `emqxConfig` is defined but does not have port like - `EMQX_LISTENER__TCP__EXTERNAL` defined.

This PR fixes this by using `if`-`else` (and `hasKey`) instead of `default`