### PR TITLE
Add helm chart service annotations

### DIFF
--- a/deploy/charts/emqx/templates/service.yaml
+++ b/deploy/charts/emqx/templates/service.yaml
@@ -8,6 +8,10 @@ metadata:
     helm.sh/chart: {{ include "emqx.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}


### PR DESCRIPTION
I saw `service.annotations` values in the README, but it seems to be missing from the service template. This PR adds the missing part to the service template.