### PR TITLE
fix(docker): Fix the error that the container log does not print

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -314,12 +314,10 @@ case "$1" in
 
         ## See: http://erlang.org/doc/man/run_erl.html
         # Export the RUN_ERL_LOG_GENERATIONS
-        # RUN_ERL_LOG_GENERATIONS=5
-        # export RUN_ERL_LOG_GENERATIONS
+        export RUN_ERL_LOG_GENERATIONS=${RUN_ERL_LOG_GENERATIONS:-"5"}
 
         # Export the RUN_ERL_LOG_MAXSIZE
-        RUN_ERL_LOG_MAXSIZE=1048576
-        export RUN_ERL_LOG_MAXSIZE
+        export RUN_ERL_LOG_MAXSIZE=${RUN_ERL_LOG_MAXSIZE:-"1048576"}
 
         mkdir -p "$PIPE_DIR"
 

--- a/deploy/docker/start.sh
+++ b/deploy/docker/start.sh
@@ -30,6 +30,9 @@ sleep 5
 
 echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx start"
 
+## Fork tailing emqx.log, the fork is not killed after this script exits
+## The assumption is that this is the docker entrypoint,
+## hence docker container is terminated after entrypoint exists
 tail -f /opt/emqx/log/emqx.log &
 
 # monitor emqx is running, or the docker must stop to let docker PaaS know
@@ -48,6 +51,6 @@ while [ $IDLE_TIME -lt 5 ]; do
     fi
     sleep 5
 done
+
 # If running to here (the result 5 times not is running, thus in 25s emqx is not running), exit docker image
 # Then the high level PaaS, e.g. docker swarm mode, will know and alert, rebanlance this service
-exit 1

--- a/deploy/docker/start.sh
+++ b/deploy/docker/start.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-set -e
+set -e -u
 
 emqx_exit(){
-    # tail erlang.log.*
-    erlang_log=$(echo $(ls -t /opt/emqx/log/erlang.log.*) | awk '{print $1}')
-    num=$(sed -n -e '/LOGGING STARTED/=' ${erlang_log} | tail -1)
-    tail -n +$((num-2)) ${erlang_log}
+    # tail emqx.log.*
+    emqx_log=$(echo $(ls -t /opt/emqx/log/emqx.log.*) | awk '{print $1}')
+    num=$(sed -n -e '/LOGGING STARTED/=' ${emqx_log} | tail -1)
+    tail -n +$((num-2)) ${emqx_log}
 
     echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx exit abnormally"
     exit 1
@@ -13,35 +13,30 @@ emqx_exit(){
 
 ## EMQ Main script
 
+# Set log.rotation=off in etc/emqx.conf
+sed -i -r 's/log.rotation = (.*)/log.rotation = off/1' /opt/emqx/etc/emqx.conf
+
 # Start and run emqx, and when emqx crashed, this container will stop
-
 /opt/emqx/bin/emqx start || emqx_exit
-
-tail -f /opt/emqx/log/erlang.log.1 &
 
 # Sleep 5 seconds to wait for the loaded plugins catch up.
 sleep 5
 
 echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx start"
 
+tail -f /opt/emqx/log/emqx.log &
+
 # monitor emqx is running, or the docker must stop to let docker PaaS know
 # warning: never use infinite loops such as `` while true; do sleep 1000; done`` here
 #          you must let user know emqx crashed and stop this container,
 #          and docker dispatching system can known and restart this container.
-NEW_LOG_NUM=2
 IDLE_TIME=0
 MGMT_CONF='/opt/emqx/etc/plugins/emqx_management.conf'
 MGMT_PORT=$(sed -n -r '/^management.listener.http[ \t]=[ \t].*$/p' $MGMT_CONF | sed -r 's/^management.listener.http = (.*)$/\1/g')
 while [[ $IDLE_TIME -lt 5 ]]; do
-    IDLE_TIME=$((IDLE_TIME+1))
+    IDLE_TIME=$(expr $IDLE_TIME + 1)
     if curl http://localhost:${MGMT_PORT}/status >/dev/null 2>&1; then
         IDLE_TIME=0
-        # Print the latest erlang.log
-        if [[ -f /opt/emqx/log/erlang.log.${NEW_LOG_NUM} ]];then
-            tail -f /opt/emqx/log/erlang.log.${NEW_LOG_NUM} &
-            [[ ! -z $(ps -ef |grep "tail -f /opt/emqx/log/erlang.log" | grep -vE "grep|erlang.log.${NEW_LOG_NUM}" | awk '{print $1}') ]] && kill $(ps -ef |grep "tail -f /opt/emqx/log/erlang.log" | grep -vE "grep|erlang.log.${NEW_LOG_NUM}" | awk '{print $1}') 
-            NEW_LOG_NUM=$((NEW_LOG_NUM+1))
-        fi
     else
         echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx not running, waiting for recovery in $((25-IDLE_TIME*5)) seconds"
     fi

--- a/deploy/docker/start.sh
+++ b/deploy/docker/start.sh
@@ -3,9 +3,8 @@ set -e -u
 
 emqx_exit(){
     # tail emqx.log.*
-    emqx_log=$(echo $(ls -t /opt/emqx/log/emqx.log.*) | awk '{print $1}')
-    num=$(sed -n -e '/LOGGING STARTED/=' ${emqx_log} | tail -1)
-    tail -n +$((num-2)) ${emqx_log}
+    num=$(sed -n -e '/LOGGING STARTED/=' /opt/emqx/log/emqx.log | tail -1)
+    tail -n +$((num-2)) /opt/emqx/log/emqx.log
 
     echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx exit abnormally"
     exit 1

--- a/deploy/docker/start.sh
+++ b/deploy/docker/start.sh
@@ -2,9 +2,13 @@
 set -e -u
 
 emqx_exit(){
-    # tail emqx.log.*
-    num=$(sed -n -e '/LOGGING STARTED/=' /opt/emqx/log/emqx.log | tail -1)
-    tail -n +$((num-2)) /opt/emqx/log/emqx.log
+    # At least erlang.log.1 exists
+    if [ -f /opt/emqx/log/erlang.log.1 ]; then
+        # tail emqx.log.*
+        erlang_log=$(echo $(ls -t /opt/emqx/log/erlang.log.*) | awk '{print $1}')
+        num=$(sed -n -e '/LOGGING STARTED/=' ${erlang_log} | tail -1)
+        [ ! -z $num ] && [ $num -gt 2 ] && tail -n +$(expr $num - 2) ${erlang_log}
+    fi
 
     echo "['$(date -u +"%Y-%m-%dT%H:%M:%SZ")']:emqx exit abnormally"
     exit 1
@@ -12,11 +16,14 @@ emqx_exit(){
 
 ## EMQ Main script
 
+# When receiving the EXIT signal, execute emqx_exit function
+trap "emqx_exit" EXIT
+
 # Set log.rotation=off in etc/emqx.conf
 sed -i -r 's/log.rotation = (.*)/log.rotation = off/1' /opt/emqx/etc/emqx.conf
 
 # Start and run emqx, and when emqx crashed, this container will stop
-/opt/emqx/bin/emqx start || emqx_exit
+/opt/emqx/bin/emqx start
 
 # Sleep 5 seconds to wait for the loaded plugins catch up.
 sleep 5
@@ -32,7 +39,7 @@ tail -f /opt/emqx/log/emqx.log &
 IDLE_TIME=0
 MGMT_CONF='/opt/emqx/etc/plugins/emqx_management.conf'
 MGMT_PORT=$(sed -n -r '/^management.listener.http[ \t]=[ \t].*$/p' $MGMT_CONF | sed -r 's/^management.listener.http = (.*)$/\1/g')
-while [[ $IDLE_TIME -lt 5 ]]; do
+while [ $IDLE_TIME -lt 5 ]; do
     IDLE_TIME=$(expr $IDLE_TIME + 1)
     if curl http://localhost:${MGMT_PORT}/status >/dev/null 2>&1; then
         IDLE_TIME=0
@@ -43,5 +50,4 @@ while [[ $IDLE_TIME -lt 5 ]]; do
 done
 # If running to here (the result 5 times not is running, thus in 25s emqx is not running), exit docker image
 # Then the high level PaaS, e.g. docker swarm mode, will know and alert, rebanlance this service
-
-emqx_exit
+exit 1


### PR DESCRIPTION
+ Fix an error where the container could not print a new log when the log content was too large

+ When the user sets the environment variables of `RUN_ERL_LOG_GENERATIONS` and `RUN_ERL_LOG_MAXSIZE`, the value set by the user is used

+ Done https://github.com/emqx/emqx/issues/3559
