### PR TITLE
fix(relup): move unpacking zipballs to install_upgrade.escript

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -474,7 +474,7 @@ case "$1" in
             exit 1
         fi
 
-        COMMAND="$1"; TO_VERSION="$2"; shift
+        COMMAND="$1"; shift
 
         # Make sure a node IS running
         if ! relx_nodetool "ping" > /dev/null; then
@@ -482,17 +482,6 @@ case "$1" in
             exit 1
         fi
 
-        ZipFile="$(pwd)/releases/${REL_NAME}-*${TO_VERSION}*.zip";
-        GzFile="$(pwd)/releases/${REL_NAME}-${TO_VERSION}.tar.gz"
-        if ls ${ZipFile} 1> /dev/null 2>&1; then
-            zipf=$(ls ${ZipFile})
-            echo "find zipball $zipf"
-            tard="/tmp/emqx_untar_$(date +%s)";
-            rm -rf ${tard} && mkdir -p "${tard}"
-            unzip -q ${zipf} -d ${tard}
-            cd ${tard}/emqx && tar zcf ${GzFile} *
-            cd -
-        fi
         ERL_FLAGS="$ERL_FLAGS $EPMD_ARG" \
         exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
              "$COMMAND" "{'$REL_NAME', \"$NAME_TYPE\", '$NAME', '$COOKIE'}" "$@"

--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -184,13 +184,16 @@ find_and_link_release_package(Version, RelName) ->
     %% we've found where the actual release package is located
     ReleaseLink = filename:join(["releases", Version,
                                  RelNameStr ++ ".tar.gz"]),
-    case first_value(fun filelib:is_file/1,
-                     [filename:join(["releases",
-                                     RelNameStr ++ "-" ++ Version ++ ".tar.gz"]),
-                      filename:join(["releases", Version,
-                                     RelNameStr ++ "-" ++ Version ++ ".tar.gz"]),
-                      filename:join(["releases", Version,
-                                     RelNameStr ++ ".tar.gz"])]) of
+    ok = unpack_zipballs(RelNameStr, Version),
+    TarBalls = [
+        filename:join(["releases",
+                        RelNameStr ++ "-" ++ Version ++ ".tar.gz"]),
+        filename:join(["releases", Version,
+                        RelNameStr ++ "-" ++ Version ++ ".tar.gz"]),
+        filename:join(["releases", Version,
+                        RelNameStr ++ ".tar.gz"])
+    ],
+    case first_value(fun filelib:is_file/1, TarBalls) of
         no_value ->
             {undefined, undefined};
         %% no need to create the link since the release package we
@@ -215,6 +218,22 @@ find_and_link_release_package(Version, RelName) ->
             end,
             {Filename, ReleaseHandlerPackageLink}
     end.
+
+unpack_zipballs(RelNameStr, Version) ->
+    {ok, Cwd} = file:get_cwd(),
+    GzFile = filename:absname(filename:join(["releases", RelNameStr ++ "-" ++ Version ++ ".tar.gz"])),
+    ZipFiles = filelib:wildcard(filename:join(["releases", RelNameStr ++ "-*" ++ Version ++ "*.zip"])),
+    ?INFO("unzip ~p~n", [ZipFiles]),
+    [begin
+        TmdTarD="/tmp/emqx_untar_" ++ integer_to_list(erlang:system_time()),
+        ok = filelib:ensure_dir(filename:join([TmdTarD, "dummy"])),
+        {ok, _} = file:copy(Zip, filename:join([TmdTarD, "emqx.zip"])),
+        ok = file:set_cwd(filename:join([TmdTarD])),
+        {ok, _FileList} = zip:unzip("emqx.zip"),
+        ok = file:set_cwd(filename:join([TmdTarD, "emqx"])),
+        ok = erl_tar:create(GzFile, filelib:wildcard("*"), [compressed])
+     end || Zip <- ZipFiles],
+    file:set_cwd(Cwd).
 
 first_value(_Fun, []) -> no_value;
 first_value(Fun, [Value | Rest]) ->


### PR DESCRIPTION
The upgrade commands with arguments not working:

```
emqx upgrade --no-permanent 4.2.1
```