### PR TITLE
chore(rpm): change owner on /usr/lib/emqx in rpm packages

### DIFF
--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -63,7 +63,6 @@ if [ -e %{_initddir}/%{_name} ] ; then
 else
     systemctl enable %{_name}.service
 fi
-chown -R %{_user}:%{_group} %{_lib_home}
 
 %preun
 %{_preun_addition}
@@ -83,11 +82,11 @@ exit 0
 %files
 %defattr(-,root,root)
 %{_service_dst}
-%{_lib_home}
-%attr(0700,%{_user},%{_group}) %dir %{_var_home}
-%attr(0700,%{_user},%{_group}) %config(noreplace) %{_var_home}/*
-%attr(0755,%{_user},%{_group}) %dir %{_log_dir}
-%attr(0755,%{_user},%{_group}) %config(noreplace) %{_conf_dir}/*
+%attr(-,%{_user},%{_group}) %{_lib_home}/*
+%attr(-,%{_user},%{_group}) %dir %{_var_home}
+%attr(-,%{_user},%{_group}) %config(noreplace) %{_var_home}/*
+%attr(-,%{_user},%{_group}) %dir %{_log_dir}
+%attr(-,%{_user},%{_group}) %config(noreplace) %{_conf_dir}/*
 
 %clean
 rm -rf %{buildroot}

--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -63,6 +63,7 @@ if [ -e %{_initddir}/%{_name} ] ; then
 else
     systemctl enable %{_name}.service
 fi
+chown -R %{_user}:%{_group} %{_lib_home}
 
 %preun
 %{_preun_addition}


### PR DESCRIPTION
This is to support hot patches to be installed by `emqx` user to `/usr/lib/emqx/releases`