### PR TITLE
feat(build): Add deterministic compile option

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -154,10 +154,10 @@
 {edoc_opts, [{preprocess,true}]}.
 
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,
-            warn_obsolete_guard,no_debug_info,compressed]}.
+            warn_obsolete_guard,no_debug_info,compressed,deterministic]}.
 
 {overrides, [
-  {add, [{erl_opts, [no_debug_info, compressed, {parse_transform, mod_vsn}]}]}
+  {add, [{erl_opts, [no_debug_info, compressed, {parse_transform, mod_vsn}, deterministic]}]}
 ]}.
 
 {xref_checks, [undefined_function_calls,undefined_functions,locals_not_used,


### PR DESCRIPTION
Omit the options and source tuples in the list returned by
Module:module_info(compile), and reduce the paths in stack traces to the
module name alone. This option will make it easier to achieve
reproducible builds.

Above is from OTP documentation https://erlang.org/doc/man/compile.html
Another reason is that the absolute path `/path/to/build/dirr/_checkout` prefix
in stacktraces are useless (no app version number in path anyway)
