### PR TITLE
support initContainers

### DIFF
--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -41,6 +41,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `persistence.existingClaim` | EMQ X data Persistent Volume existing claim name, evaluated as a template |""|
 | `persistence.accessMode` | PVC Access Mode for EMQX volume |ReadWriteOnce|
 | `persistence.size` | PVC Storage Request for EMQX volume |20Mi|
+| `initContainers` | Containers that run before the creation of EMQX containers. They can contain utilities or setup scripts. |`{}`|
 | `resources` | CPU/Memory resource requests/limits |{}|
 | `nodeSelector` | Node labels for pod assignment |`{}`|
 | `tolerations` | Toleration labels for pod assignment |`[]`|

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -73,6 +73,10 @@ spec:
       serviceAccountName:  {{ include "emqx.fullname" . }}
       securityContext:
         fsGroup: 1000
+      {{- if .Values.initContainers }}
+      initContainers:
+{{ toYaml .Values.initContainers | indent 8 }}
+      {{- end }}
       containers:
         - name: emqx
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -28,6 +28,11 @@ resources: {}
   #   cpu: 500m
   #   memory: 512Mi
 
+initContainers: {}
+  # - name: mysql-probe
+  #   image: alpine
+  #   command: ["sh", "-c", "for i in $(seq 1 300); do nc -zvw1 mysql 3306 && exit 0 || sleep 3; done; exit 1"]
+
 ## EMQX configuration item, see the documentation (https://github.com/emqx/emqx-docker#emq-x-configuration)
 emqxConfig:
   EMQX_CLUSTER__K8S__APISERVER: "https://kubernetes.default.svc:443"

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -28,6 +28,7 @@ resources: {}
   #   cpu: 500m
   #   memory: 512Mi
 
+# Containers that run before the creation of EMQX containers. They can contain utilities or setup scripts.
 initContainers: {}
   # - name: mysql-probe
   #   image: alpine


### PR DESCRIPTION
When EMQX has to work together with other services on kubernetes (like MySQL for `emqx-auth-mysql` plugin), you can take advantage of `initContainers` to wait for other resources to be created.