### PR TITLE
Move pullSecrets up to pod level

### DIFF
--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -77,16 +77,16 @@ spec:
       initContainers:
 {{ toYaml .Values.initContainers | indent 8 }}
       {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: emqx
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.image.pullSecrets }}
-          imagePullSecrets:
-          {{- range .Values.image.pullSecrets }}
-          - name: {{ . }}
-          {{- end }}
-          {{- end }}
           ports:
           - name: mqtt
             containerPort: {{ .Values.emqxConfig.EMQX_LISTENER__TCP__EXTERNAL | default 1883 }}
@@ -104,14 +104,14 @@ spec:
             containerPort: 4370
           envFrom:
             - configMapRef:
-                name: {{ include "emqx.fullname" . }}-env 
+                name: {{ include "emqx.fullname" . }}-env
           env:
           - name: EMQX_NAME
-            value: {{ .Release.Name }} 
+            value: {{ .Release.Name }}
           - name: EMQX_CLUSTER__K8S__APP_NAME
-            value: {{ .Release.Name }} 
+            value: {{ .Release.Name }}
           - name: EMQX_CLUSTER__DISCOVERY
-            value: k8s 
+            value: k8s
           - name: EMQX_CLUSTER__K8S__SERVICE_NAME
             value: {{ include "emqx.fullname" . }}-headless
           - name: EMQX_CLUSTER__K8S__NAMESPACE


### PR DESCRIPTION
This pull request moves the `imagePullSecrets` one level up to match the kubernetes api.