### PR TITLE
fix(helm): add externalIPs to chart

### DIFF
--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `service.nodePorts.dashboard`  | Kubernetes node port for dashboard. |nil|
 | `service.loadBalancerIP`  | loadBalancerIP for Service |	nil |
 | `service.loadBalancerSourceRanges` |	Address(es) that are allowed when service is LoadBalancer |	[] |
+| `service.externalIPs` |	ExternalIPs for the service |	[] |
 | `service.annotations` |	Service annotations |	{}(evaluated as a template)|
 | `ingress.dashboard.enabled` |	Enable ingress for EMQX Dashboard |	false |
 | `ingress.dashboard.path` | Ingress path for EMQX Dashboard |	/ |

--- a/deploy/charts/emqx/templates/service.yaml
+++ b/deploy/charts/emqx/templates/service.yaml
@@ -21,6 +21,9 @@ spec:
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs: {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
   {{- end }}
   ports:
   - name: mqtt

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -122,6 +122,9 @@ service:
   ## - 10.10.10.0/24
   ##
   loadBalancerSourceRanges: []
+  ## Set the ExternalIPs
+  ##
+  externalIPs: []
   ## Provide any additional annotations which may be required. Evaluated as a template
   ##
   annotations: {}


### PR DESCRIPTION
Let `externalIPs` be configurable in the Helm chart